### PR TITLE
Add hierarchy to Tuples

### DIFF
--- a/src/javax/vecmath/Tuple.java
+++ b/src/javax/vecmath/Tuple.java
@@ -16,6 +16,14 @@ implements java.io.Serializable, Cloneable {
 	public abstract void sub(T t1);
 	public abstract void sub(T t1, T t2);
 
+	/**
+	 * Returns true if the data members of t1 are equal to the corresponding
+	 * data members in this Tuple.
+	 * @param t1  the tuple with which the comparison is made
+	 * @return  true or false
+	 */
+	public abstract boolean equals(T t);
+
 	public Object clone() {
 		try {
 			return super.clone();

--- a/src/javax/vecmath/Tuple.java
+++ b/src/javax/vecmath/Tuple.java
@@ -1,0 +1,25 @@
+package javax.vecmath;
+
+public abstract class Tuple<T extends Tuple<T>> {
+
+	public abstract void absolute();
+	public abstract void absolute(T t);
+	public abstract void add(T t);
+	public abstract void add(T t1, T t2);
+	public abstract void get(T t);
+	public abstract void negate();
+	public abstract void negate(T t);
+	public abstract void set(T t);
+	public abstract void sub(T t1);
+	public abstract void sub(T t1, T t2);
+
+	public Object clone() {
+		try {
+			return super.clone();
+		} catch (CloneNotSupportedException e) {
+			// this shouldn't happen, since we are Cloneable
+			throw new InternalError();
+		}
+	}
+
+}

--- a/src/javax/vecmath/Tuple.java
+++ b/src/javax/vecmath/Tuple.java
@@ -1,19 +1,84 @@
 package javax.vecmath;
 
+/**
+ * This is the top-level class of the hierarchy of Tuples. It specifies
+ * methods which accept as their arguments other Tuples of the same number
+ * and type as the Tuple on which the method is invoked, or methods which
+ * accept no arguments. Methods which accept primitives are specified by the
+ * subclasses of Tuple.
+ *
+ * @param <T> The type of this tuple as a subclass of Tuple; the number and
+ *   type of primitives held by this Tuple are determined by this parameter.
+ *   Subclasses of Tuple should provide themselves to fill this parameter.
+ *
+ * @since 1.6
+ */
 public abstract class Tuple<T extends Tuple<T>>
 implements java.io.Serializable, Cloneable {
 
-    private static final long serialVersionUID = 2172728256449529639L;
+	private static final long serialVersionUID = 2172728256449529639L;
 
+	/**
+	 * Sets each component of this tuple to its absolute value.
+	 */
 	public abstract void absolute();
+
+	/**
+	 * Sets each component of the tuple parameter to its absolute
+	 * value and places the modified values into this tuple.
+	 * @param t   the source tuple, which will not be modified
+	 */
 	public abstract void absolute(T t);
-	public abstract void add(T t);
+
+	/**
+	 * Sets the value of this tuple to the vector sum of itself and tuple t1.
+	 * @param t1 the other tuple
+	 */
+	public abstract void add(T t1);
+
+	/**
+	 * Sets the value of this tuple to the vector sum of tuples t1 and t2.
+	 * @param t1 the first tuple
+	 * @param t2 the second tuple
+	 */
 	public abstract void add(T t1, T t2);
+
+	/**
+	 * Gets the value of this tuple and copies the values into t.
+	 * @param t  the Tuple object into which the values of this object are copied
+	 */
 	public abstract void get(T t);
+
+	/**
+	 * Negates the value of this tuple in place.
+	 */
 	public abstract void negate();
+
+	/**
+	 * Sets the value of this tuple to the negation of tuple t1.
+	 * @param t1 the source tuple
+	 */
 	public abstract void negate(T t);
+
+	/**
+	 * Sets the value of this tuple to the value of tuple t1.
+	 * @param t1 the tuple to be copied
+	 */
 	public abstract void set(T t);
+
+	/**
+	 * Sets the value of this tuple to the vector difference of
+	 * itself and tuple t1 (this = this - t1) .
+	 * @param t1 the other tuple
+	 */
 	public abstract void sub(T t1);
+
+	/**
+	 * Sets the value of this tuple to the vector difference
+	 * of tuples t1 and t2 (this = t1 - t2).
+	 * @param t1 the first tuple
+	 * @param t2 the second tuple
+	 */
 	public abstract void sub(T t1, T t2);
 
 	/**

--- a/src/javax/vecmath/Tuple.java
+++ b/src/javax/vecmath/Tuple.java
@@ -1,6 +1,9 @@
 package javax.vecmath;
 
-public abstract class Tuple<T extends Tuple<T>> {
+public abstract class Tuple<T extends Tuple<T>>
+implements java.io.Serializable, Cloneable {
+
+    private static final long serialVersionUID = 2172728256449529639L;
 
 	public abstract void absolute();
 	public abstract void absolute(T t);

--- a/src/javax/vecmath/Tuple2d.java
+++ b/src/javax/vecmath/Tuple2d.java
@@ -32,7 +32,8 @@ package javax.vecmath;
  * floating point x,y coordinates.
  *
  */
-public abstract class Tuple2d implements java.io.Serializable, Cloneable {
+public abstract class Tuple2d extends Tupled<Tuple2d>
+implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = 6205762482756093838L;
 
@@ -154,6 +155,18 @@ public abstract class Tuple2d implements java.io.Serializable, Cloneable {
     {
         t[0] = this.x;
         t[1] = this.y;
+    }
+
+
+    /**
+     * Copies the x and y coordinates of this tuple into the tuple t.
+     * @param t the Tuple2d object into which the values of this object are copied
+     * @since vecmath 1.6
+     */
+    public final void get(Tuple2d t)
+    {
+        t.x = this.x;
+        t.y = this.y;
     }
 
 
@@ -533,26 +546,6 @@ public abstract class Tuple2d implements java.io.Serializable, Cloneable {
        this.y = (1-alpha)*this.y + alpha*t1.y;
 
   }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
-
 
 	/**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tuple2d.java
+++ b/src/javax/vecmath/Tuple2d.java
@@ -32,8 +32,7 @@ package javax.vecmath;
  * floating point x,y coordinates.
  *
  */
-public abstract class Tuple2d extends Tupled<Tuple2d>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple2d extends Tupled<Tuple2d> {
 
     static final long serialVersionUID = 6205762482756093838L;
 

--- a/src/javax/vecmath/Tuple2f.java
+++ b/src/javax/vecmath/Tuple2f.java
@@ -32,7 +32,7 @@ package javax.vecmath;
  * floating point x,y coordinates.
  *
  */
-public abstract class Tuple2f implements java.io.Serializable, Cloneable {
+public abstract class Tuple2f extends Tuplef<Tuple2f> implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = 9011180388985266884L;
 
@@ -157,6 +157,18 @@ public abstract class Tuple2f implements java.io.Serializable, Cloneable {
         t[0] = this.x;
         t[1] = this.y;
     }
+
+
+   /**
+    * Copies the x and y coordinates of this tuple into the tuple t.
+    * @param t the Tuple2f object into which the values of this object are copied
+    * @since vecmath 1.6
+    */
+   public final void get(Tuple2f t)
+   {
+       t.x = this.x;
+       t.y = this.y;
+   }
 
 
     /**
@@ -537,26 +549,6 @@ public abstract class Tuple2f implements java.io.Serializable, Cloneable {
      this.y = (1-alpha)*this.y + alpha*t1.y;
 
   }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
-
 
     /**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tuple2f.java
+++ b/src/javax/vecmath/Tuple2f.java
@@ -32,7 +32,7 @@ package javax.vecmath;
  * floating point x,y coordinates.
  *
  */
-public abstract class Tuple2f extends Tuplef<Tuple2f> implements java.io.Serializable, Cloneable {
+public abstract class Tuple2f extends Tuplef<Tuple2f> {
 
     static final long serialVersionUID = 9011180388985266884L;
 

--- a/src/javax/vecmath/Tuple2i.java
+++ b/src/javax/vecmath/Tuple2i.java
@@ -33,7 +33,7 @@ package javax.vecmath;
  *
  * @since vecmath 1.4
  */
-public abstract class Tuple2i extends Tuplei<Tuple2i> implements java.io.Serializable, Cloneable {
+public abstract class Tuple2i extends Tuplei<Tuple2i> {
 
     static final long serialVersionUID = -3555701650170169638L;
 

--- a/src/javax/vecmath/Tuple2i.java
+++ b/src/javax/vecmath/Tuple2i.java
@@ -286,6 +286,16 @@ public abstract class Tuple2i extends Tuplei<Tuple2i> {
     }
 
 
+    @Override
+    public boolean equals(Tuple2i t1) {
+        try {
+            return (this.x == t1.x && this.y == t1.y);
+        } catch (NullPointerException e2) {
+            return false;
+        }
+    }
+
+
     /**
      * Returns a hash code value based on the data values in this
      * object.  Two different Tuple2i objects with identical data values

--- a/src/javax/vecmath/Tuple2i.java
+++ b/src/javax/vecmath/Tuple2i.java
@@ -33,7 +33,7 @@ package javax.vecmath;
  *
  * @since vecmath 1.4
  */
-public abstract class Tuple2i implements java.io.Serializable, Cloneable {
+public abstract class Tuple2i extends Tuplei<Tuple2i> implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = -3555701650170169638L;
 
@@ -435,25 +435,6 @@ public abstract class Tuple2i implements java.io.Serializable, Cloneable {
 	x = Math.abs(x);
 	y = Math.abs(y);
     }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
-
 
     /**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tuple3d.java
+++ b/src/javax/vecmath/Tuple3d.java
@@ -32,8 +32,7 @@ package javax.vecmath;
  * floating point x,y,z coordinates.
  *
  */
-public abstract class Tuple3d extends Tupled<Tuple3d>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple3d extends Tupled<Tuple3d> {
 
     static final long serialVersionUID = 5542096614926168415L;
 

--- a/src/javax/vecmath/Tuple3d.java
+++ b/src/javax/vecmath/Tuple3d.java
@@ -32,7 +32,8 @@ package javax.vecmath;
  * floating point x,y,z coordinates.
  *
  */
-public abstract class Tuple3d implements java.io.Serializable, Cloneable {
+public abstract class Tuple3d extends Tupled<Tuple3d>
+implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = 5542096614926168415L;
 
@@ -663,25 +664,6 @@ public abstract class Tuple3d implements java.io.Serializable, Cloneable {
 	this.x = (1-alpha)*this.x + alpha*t1.x;
 	this.y = (1-alpha)*this.y + alpha*t1.y;
 	this.z = (1-alpha)*this.z + alpha*t1.z;
-    }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
     }
 
     /**

--- a/src/javax/vecmath/Tuple3f.java
+++ b/src/javax/vecmath/Tuple3f.java
@@ -32,8 +32,7 @@ package javax.vecmath;
  * point x,y,z coordinates.
  *
  */
-public abstract class Tuple3f extends Tuplef<Tuple3f>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple3f extends Tuplef<Tuple3f> {
 
     static final long serialVersionUID=5019834619484343712L;
 

--- a/src/javax/vecmath/Tuple3f.java
+++ b/src/javax/vecmath/Tuple3f.java
@@ -138,11 +138,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the xyz coordinates specified in
-     * the array of length 3.
-     * @param t the array of length 3 containing xyz in order
-     */
     public final void set(float[] t)
     {
 	this.x = t[0];
@@ -151,10 +146,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the value of tuple t1.
-     * @param t1 the tuple to be copied
-     */
     public final void set(Tuple3f t1)
     {
 	this.x = t1.x;
@@ -175,10 +166,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-   /**
-     * Gets the value of this tuple and copies the values into t.
-     * @param t  the array of length 3 into which the values are copied
-     */
     public final void get(float[] t)
     {
        t[0] = this.x;
@@ -187,10 +174,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-   /**
-     * Gets the value of this tuple and copies the values into t.
-     * @param t  the Tuple3f object into which the values of this object are copied
-     */
     public final void get(Tuple3f t)
     {
        t.x = this.x;
@@ -199,11 +182,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the vector sum of tuples t1 and t2.
-     * @param t1 the first tuple
-     * @param t2 the second tuple
-     */
     public final void add(Tuple3f t1, Tuple3f t2)
     {
 	this.x = t1.x + t2.x;
@@ -212,10 +190,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the vector sum of itself and tuple t1.
-     * @param t1 the other tuple
-     */
     public final void add(Tuple3f t1)
     {
         this.x += t1.x;
@@ -224,12 +198,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the vector difference
-     * of tuples t1 and t2 (this = t1 - t2).
-     * @param t1 the first tuple
-     * @param t2 the second tuple
-     */
     public final void sub(Tuple3f t1, Tuple3f t2)
     {
 	this.x = t1.x - t2.x;
@@ -238,11 +206,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-   /**
-     * Sets the value of this tuple to the vector difference of
-     * itself and tuple t1 (this = this - t1) .
-     * @param t1 the other tuple
-     */
     public final void sub(Tuple3f t1)
     {
         this.x -= t1.x;
@@ -251,10 +214,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the negation of tuple t1.
-     * @param t1 the source tuple
-     */
     public final void negate(Tuple3f t1)
     {
 	this.x = -t1.x;
@@ -263,9 +222,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Negates the value of this tuple in place.
-     */
     public final void negate()
     {
 	this.x = -this.x;
@@ -274,12 +230,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this vector to the scalar multiplication
-     * of tuple t1.
-     * @param s the scalar value
-     * @param t1 the source tuple
-     */
     public final void scale(float s, Tuple3f t1)
     {
 	this.x = s*t1.x;
@@ -288,11 +238,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the scalar multiplication
-     * of the scale factor with this.
-     * @param s the scalar value
-     */
     public final void scale(float s)
     {
 	this.x *= s;
@@ -301,13 +246,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-    /**
-     * Sets the value of this tuple to the scalar multiplication
-     * of tuple t1 and then adds tuple t2 (this = s*t1 + t2).
-     * @param s the scalar value
-     * @param t1 the tuple to be scaled and added
-     * @param t2 the tuple to be added without a scale
-     */
     public final void scaleAdd(float s, Tuple3f t1, Tuple3f t2)
     {
 	this.x = s*t1.x + t2.x;
@@ -316,13 +254,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-
-    /**
-     * Sets the value of this tuple to the scalar multiplication
-     * of itself and then adds tuple t1 (this = s*this + t1).
-     * @param s the scalar value
-     * @param t1 the tuple to be added
-     */
     public final void scaleAdd(float s, Tuple3f t1)
     {
         this.x = s*this.x + t1.x;
@@ -331,13 +262,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
     }
 
 
-   /**
-     * Returns true if the Object t1 is of type Tuple3f and all of the
-     * data members of t1 are equal to the corresponding data members in
-     * this Tuple3f.
-     * @param t1  the vector with which the comparison is made
-     * @return  true or false
-     */
     public boolean equals(Tuple3f t1)
     {
         try {
@@ -345,6 +269,7 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
         }
         catch (NullPointerException e2) {return false;}
     }
+
    /**
      * Returns true if the Object t1 is of type Tuple3f and all of the
      * data members of t1 are equal to the corresponding data members in
@@ -413,13 +338,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
 
 
 
-  /**
-    *  Clamps the tuple parameter to the range [low, high] and
-    *  places the values into this tuple.
-    *  @param min   the lowest value in the tuple after clamping
-    *  @param max  the highest value in the tuple after clamping
-    *  @param t   the source tuple, which will not be modified
-    */
    public final void clamp(float min, float max, Tuple3f t)
    {
         if( t.x > max ) {
@@ -449,12 +367,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
    }
 
 
-  /**
-    *  Clamps the minimum value of the tuple parameter to the min
-    *  parameter and places the values into this tuple.
-    *  @param min   the lowest value in the tuple after clamping
-    *  @param t   the source tuple, which will not be modified
-    */
    public final void clampMin(float min, Tuple3f t)
    {
         if( t.x < min ) {
@@ -478,12 +390,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
    }
 
 
-  /**
-    *  Clamps the maximum value of the tuple parameter to the max
-    *  parameter and places the values into this tuple.
-    *  @param max   the highest value in the tuple after clamping
-    *  @param t   the source tuple, which will not be modified
-    */
    public final void clampMax(float max, Tuple3f t)
    {
         if( t.x > max ) {
@@ -507,11 +413,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
    }
 
 
-  /**
-    *  Sets each component of the tuple parameter to its absolute
-    *  value and places the modified values into this tuple.
-    *  @param t   the source tuple, which will not be modified
-    */
   public final void absolute(Tuple3f t)
   {
        x = Math.abs(t.x);
@@ -520,12 +421,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
   }
 
 
-
-  /**
-    *  Clamps this tuple to the range [low, high].
-    *  @param min  the lowest value in this tuple after clamping
-    *  @param max  the highest value in this tuple after clamping
-    */
    public final void clamp(float min, float max)
    {
         if( x > max ) {
@@ -549,10 +444,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
    }
 
 
-  /**
-    *  Clamps the minimum value of this tuple to the min parameter.
-    *  @param min   the lowest value in this tuple after clamping
-    */
    public final void clampMin(float min)
    {
       if( x < min ) x=min;
@@ -562,10 +453,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
    }
 
 
-  /**
-    *  Clamps the maximum value of this tuple to the max parameter.
-    *  @param max   the highest value in the tuple after clamping
-    */
    public final void clampMax(float max)
    {
       if( x > max ) x=max;
@@ -575,9 +462,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
    }
 
 
-  /**
-    *  Sets each component of this tuple to its absolute value.
-    */
   public final void absolute()
   {
      x = Math.abs(x);
@@ -587,13 +471,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
   }
 
 
-  /**
-    *  Linearly interpolates between tuples t1 and t2 and places the
-    *  result into this tuple:  this = (1-alpha)*t1 + alpha*t2.
-    *  @param t1  the first tuple
-    *  @param t2  the second tuple
-    *  @param alpha  the alpha interpolation parameter
-    */
   public final void interpolate(Tuple3f t1, Tuple3f t2, float alpha)
   {
            this.x = (1-alpha)*t1.x + alpha*t2.x;
@@ -604,12 +481,6 @@ public abstract class Tuple3f extends Tuplef<Tuple3f> {
   }
 
 
-  /**
-    *  Linearly interpolates between this tuple and tuple t1 and
-    *  places the result into this tuple:  this = (1-alpha)*this + alpha*t1.
-    *  @param t1  the first tuple
-    *  @param alpha  the alpha interpolation parameter
-    */
   public final void interpolate(Tuple3f t1, float alpha)
   {
      this.x = (1-alpha)*this.x + alpha*t1.x;

--- a/src/javax/vecmath/Tuple3f.java
+++ b/src/javax/vecmath/Tuple3f.java
@@ -32,7 +32,8 @@ package javax.vecmath;
  * point x,y,z coordinates.
  *
  */
-public abstract class Tuple3f implements java.io.Serializable, Cloneable {
+public abstract class Tuple3f extends Tuplef<Tuple3f>
+implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID=5019834619484343712L;
 
@@ -618,26 +619,6 @@ public abstract class Tuple3f implements java.io.Serializable, Cloneable {
 
 
   }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
-
 
     /**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tuple3i.java
+++ b/src/javax/vecmath/Tuple3i.java
@@ -33,7 +33,8 @@ package javax.vecmath;
  *
  * @since vecmath 1.2
  */
-public abstract class Tuple3i implements java.io.Serializable, Cloneable {
+public abstract class Tuple3i extends Tuplei<Tuple3i>
+implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = -732740491767276200L;
 
@@ -496,26 +497,6 @@ public abstract class Tuple3i implements java.io.Serializable, Cloneable {
 	y = Math.abs(y);
 	z = Math.abs(z);
     }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
-
 
     /**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tuple3i.java
+++ b/src/javax/vecmath/Tuple3i.java
@@ -33,8 +33,7 @@ package javax.vecmath;
  *
  * @since vecmath 1.2
  */
-public abstract class Tuple3i extends Tuplei<Tuple3i>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple3i extends Tuplei<Tuple3i> {
 
     static final long serialVersionUID = -732740491767276200L;
 

--- a/src/javax/vecmath/Tuple3i.java
+++ b/src/javax/vecmath/Tuple3i.java
@@ -312,6 +312,16 @@ public abstract class Tuple3i extends Tuplei<Tuple3i> {
     }
 
 
+    @Override
+    public boolean equals(Tuple3i t1) {
+        try {
+            return (this.x == t1.x && this.y == t1.y && this.z == t1.z);
+        } catch (NullPointerException e2) {
+            return false;
+        }
+    }
+
+
     /**
      * Returns a hash code value based on the data values in this
      * object.  Two different Tuple3i objects with identical data values

--- a/src/javax/vecmath/Tuple4d.java
+++ b/src/javax/vecmath/Tuple4d.java
@@ -32,8 +32,7 @@ package javax.vecmath;
  * x,y,z,w coordinates.
  *
  */
-public abstract class Tuple4d extends Tupled<Tuple4d>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple4d extends Tupled<Tuple4d> {
 
     static final long serialVersionUID = -4748953690425311052L;
 

--- a/src/javax/vecmath/Tuple4d.java
+++ b/src/javax/vecmath/Tuple4d.java
@@ -32,7 +32,8 @@ package javax.vecmath;
  * x,y,z,w coordinates.
  *
  */
-public abstract class Tuple4d implements java.io.Serializable, Cloneable {
+public abstract class Tuple4d extends Tupled<Tuple4d>
+implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = -4748953690425311052L;
 
@@ -748,25 +749,6 @@ public abstract class Tuple4d implements java.io.Serializable, Cloneable {
 	this.y = (1-alpha)*this.y + alpha*t1.y;
 	this.z = (1-alpha)*this.z + alpha*t1.z;
 	this.w = (1-alpha)*this.w + alpha*t1.w;
-    }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
     }
 
     /**

--- a/src/javax/vecmath/Tuple4f.java
+++ b/src/javax/vecmath/Tuple4f.java
@@ -32,8 +32,7 @@ package javax.vecmath;
  * coordinates.
  *
  */
-public abstract class Tuple4f extends Tuplef<Tuple4f>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple4f extends Tuplef<Tuple4f> {
 
   static final long serialVersionUID =  7068460319248845763L;
 

--- a/src/javax/vecmath/Tuple4f.java
+++ b/src/javax/vecmath/Tuple4f.java
@@ -32,7 +32,8 @@ package javax.vecmath;
  * coordinates.
  *
  */
-public abstract class Tuple4f implements java.io.Serializable, Cloneable {
+public abstract class Tuple4f extends Tuplef<Tuple4f>
+implements java.io.Serializable, Cloneable {
 
   static final long serialVersionUID =  7068460319248845763L;
 
@@ -680,25 +681,6 @@ public abstract class Tuple4f implements java.io.Serializable, Cloneable {
      this.w = (1-alpha)*this.w + alpha*t1.w;
 
   }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
 
     /**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tuple4i.java
+++ b/src/javax/vecmath/Tuple4i.java
@@ -340,6 +340,17 @@ public abstract class Tuple4i extends Tuplei<Tuple4i> {
     }
 
 
+    @Override
+    public boolean equals(Tuple4i t1) {
+        try {
+            return (this.x == t1.x && this.y == t1.y &&
+                    this.z == t1.z && this.w == t1.w);
+        } catch (NullPointerException e2) {
+            return false;
+        }
+    }
+
+
     /**
      * Returns a hash code value based on the data values in this
      * object.  Two different Tuple4i objects with identical data values

--- a/src/javax/vecmath/Tuple4i.java
+++ b/src/javax/vecmath/Tuple4i.java
@@ -33,8 +33,7 @@ package javax.vecmath;
  *
  * @since vecmath 1.2
  */
-public abstract class Tuple4i extends Tuplei<Tuple4i>
-implements java.io.Serializable, Cloneable {
+public abstract class Tuple4i extends Tuplei<Tuple4i> {
 
     static final long serialVersionUID = 8064614250942616720L;
 

--- a/src/javax/vecmath/Tuple4i.java
+++ b/src/javax/vecmath/Tuple4i.java
@@ -33,7 +33,8 @@ package javax.vecmath;
  *
  * @since vecmath 1.2
  */
-public abstract class Tuple4i implements java.io.Serializable, Cloneable {
+public abstract class Tuple4i extends Tuplei<Tuple4i>
+implements java.io.Serializable, Cloneable {
 
     static final long serialVersionUID = 8064614250942616720L;
 
@@ -561,27 +562,6 @@ public abstract class Tuple4i implements java.io.Serializable, Cloneable {
 	z = Math.abs(z);
 	w = Math.abs(w);
     }
-
-    /**
-     * Creates a new object of the same class as this object.
-     *
-     * @return a clone of this instance.
-     * @exception OutOfMemoryError if there is not enough memory.
-     * @see java.lang.Cloneable
-     * @since vecmath 1.3
-     */
-    @Override
-    public Object clone() {
-	// Since there are no arrays we can just use Object.clone()
-	try {
-	    return super.clone();
-	} catch (CloneNotSupportedException e) {
-	    // this shouldn't happen, since we are Cloneable
-	    throw new InternalError();
-	}
-    }
-
-
 
     /**
 	 * Get the <i>x</i> coordinate.

--- a/src/javax/vecmath/Tupled.java
+++ b/src/javax/vecmath/Tupled.java
@@ -1,0 +1,18 @@
+package javax.vecmath;
+
+public abstract class Tupled<T extends Tupled<T>> extends Tuple<T> {
+
+	public abstract void clamp(double min, double max);
+	public abstract void clamp(double min, double max, T t);
+	public abstract void clampMax(double max);
+	public abstract void clampMax(double max, T t);
+	public abstract void clampMin(double min);
+	public abstract void clampMin(double min, T t);
+	public abstract void get(double[] t);
+	public abstract void scale(double s);
+	public abstract void scale(double s, T t);
+	public abstract void scaleAdd(double s, T t);
+	public abstract void scaleAdd(double s, T t1, T t2);
+	public abstract void set(double[] t);
+
+}

--- a/src/javax/vecmath/Tupled.java
+++ b/src/javax/vecmath/Tupled.java
@@ -102,4 +102,32 @@ public abstract class Tupled<T extends Tupled<T>> extends Tuple<T> {
 	 */
 	public abstract void set(double[] t);
 
+	/**
+	 * Returns true if the L-infinite distance between this tuple
+	 * and tuple t1 is less than or equal to the epsilon parameter,
+	 * otherwise returns false.  The L-infinite distance is equal to
+	 * MAX[abs(x1-x2), abs(y1-y2), abs(z1-z2)] for a tuple with 3 parts.
+	 * @param t1  the tuple to be compared to this tuple
+	 * @param epsilon  the threshold value
+	 * @return  true or false
+	 */
+	public abstract boolean epsilonEquals(T t, double epsilon);
+
+	/**
+	 *  Linearly interpolates between this tuple and tuple t1 and
+	 *  places the result into this tuple:  this = (1-alpha)*this + alpha*t1.
+	 *  @param t1  the first tuple
+	 *  @param alpha  the alpha interpolation parameter
+	 */
+	public abstract void interpolate(T t1, double alpha);
+
+	/**
+	 *  Linearly interpolates between tuples t1 and t2 and places the
+	 *  result into this tuple:  this = (1-alpha)*t1 + alpha*t2.
+	 *  @param t1  the first tuple
+	 *  @param t2  the second tuple
+	 *  @param alpha  the alpha interpolation parameter
+	 */
+	public abstract void interpolate(T t1, T t2, double alpha);
+
 }

--- a/src/javax/vecmath/Tupled.java
+++ b/src/javax/vecmath/Tupled.java
@@ -2,6 +2,8 @@ package javax.vecmath;
 
 public abstract class Tupled<T extends Tupled<T>> extends Tuple<T> {
 
+	private static final long serialVersionUID = -3801927462376993083L;
+
 	public abstract void clamp(double min, double max);
 	public abstract void clamp(double min, double max, T t);
 	public abstract void clampMax(double max);

--- a/src/javax/vecmath/Tupled.java
+++ b/src/javax/vecmath/Tupled.java
@@ -1,20 +1,105 @@
 package javax.vecmath;
 
+/**
+ * This class describes a Tuple that holds doubles. The number of doubles is
+ * determined by subclasses. 
+ *
+ * @param <T> The type of this tuple. Subclasses should provide themselves to
+ *   fill this parameter.
+ *
+ * @since 1.6
+ */
 public abstract class Tupled<T extends Tupled<T>> extends Tuple<T> {
 
 	private static final long serialVersionUID = -3801927462376993083L;
 
+	/**
+	 *  Clamps this tuple to the range [low, high].
+	 *  @param min  the lowest value in this tuple after clamping
+	 *  @param max  the highest value in this tuple after clamping
+	 */
 	public abstract void clamp(double min, double max);
+
+	/**
+	 *  Clamps the tuple parameter to the range [low, high] and
+	 *  places the values into this tuple.
+	 *  @param min   the lowest value in the tuple after clamping
+	 *  @param max  the highest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clamp(double min, double max, T t);
+
+	/**
+	 *  Clamps the maximum value of this tuple to the max parameter.
+	 *  @param max   the highest value in the tuple after clamping
+	 */
 	public abstract void clampMax(double max);
+
+	/**
+	 *  Clamps the maximum value of the tuple parameter to the max
+	 *  parameter and places the values into this tuple.
+	 *  @param max   the highest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clampMax(double max, T t);
+
+	/**
+	 *  Clamps the minimum value of this tuple to the min parameter.
+	 *  @param min   the lowest value in this tuple after clamping
+	 */
 	public abstract void clampMin(double min);
+
+	/**
+	 *  Clamps the minimum value of the tuple parameter to the min
+	 *  parameter and places the values into this tuple.
+	 *  @param min   the lowest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clampMin(double min, T t);
+
+	/**
+	 * Gets the value of this tuple and copies the values into t.
+	 * @param t  the array into which the values are copied
+	 */
 	public abstract void get(double[] t);
+
+	/**
+	 * Sets the value of this vector to the scalar multiplication
+	 * of tuple t1.
+	 * @param s the scalar value
+	 * @param t1 the source tuple
+	 */
 	public abstract void scale(double s);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of the scale factor with this.
+	 * @param s the scalar value
+	 */
 	public abstract void scale(double s, T t);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of itself and then adds tuple t1 (this = s*this + t1).
+	 * @param s the scalar value
+	 * @param t1 the tuple to be added
+	 */
 	public abstract void scaleAdd(double s, T t);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of tuple t1 and then adds tuple t2 (this = s*t1 + t2).
+	 * @param s the scalar value
+	 * @param t1 the tuple to be scaled and added
+	 * @param t2 the tuple to be added without a scale
+	 */
 	public abstract void scaleAdd(double s, T t1, T t2);
+
+	/**
+	 * Sets the value of this tuple to the coordinates specified in
+	 * the array.
+	 * @param t the array containing the coordintes in order
+	 */
 	public abstract void set(double[] t);
 
 }

--- a/src/javax/vecmath/Tuplef.java
+++ b/src/javax/vecmath/Tuplef.java
@@ -1,0 +1,18 @@
+package javax.vecmath;
+
+public abstract class Tuplef<T extends Tuplef<T>> extends Tuple<T> {
+
+	public abstract void clamp(float min, float max);
+	public abstract void clamp(float min, float max, T t);
+	public abstract void clampMax(float max);
+	public abstract void clampMax(float max, T t);
+	public abstract void clampMin(float min);
+	public abstract void clampMin(float min, T t);
+	public abstract void get(float[] t);
+	public abstract void scale(float s);
+	public abstract void scale(float s, T t);
+	public abstract void scaleAdd(float s, T t);
+	public abstract void scaleAdd(float s, T t1, T t2);
+	public abstract void set(float[] t);
+
+}

--- a/src/javax/vecmath/Tuplef.java
+++ b/src/javax/vecmath/Tuplef.java
@@ -102,4 +102,21 @@ public abstract class Tuplef<T extends Tuplef<T>> extends Tuple<T> {
 	 */
 	public abstract void set(float[] t);
 
+	/**
+	 *  Linearly interpolates between this tuple and tuple t1 and
+	 *  places the result into this tuple:  this = (1-alpha)*this + alpha*t1.
+	 *  @param t1  the first tuple
+	 *  @param alpha  the alpha interpolation parameter
+	 */
+	public abstract void interpolate(T t1, float alpha);
+
+	/**
+	 *  Linearly interpolates between tuples t1 and t2 and places the
+	 *  result into this tuple:  this = (1-alpha)*t1 + alpha*t2.
+	 *  @param t1  the first tuple
+	 *  @param t2  the second tuple
+	 *  @param alpha  the alpha interpolation parameter
+	 */
+	public abstract void interpolate(T t1, T t2, float alpha);
+
 }

--- a/src/javax/vecmath/Tuplef.java
+++ b/src/javax/vecmath/Tuplef.java
@@ -1,20 +1,105 @@
 package javax.vecmath;
 
+/**
+ * This class describes a Tuple that holds floats. The number of floats is
+ * determined by subclasses.
+ *
+ * @param <T> The type of this tuple. Subclasses should provide themselves to
+ *   fill this parameter.
+ *
+ * @since 1.6
+ */
 public abstract class Tuplef<T extends Tuplef<T>> extends Tuple<T> {
 
 	private static final long serialVersionUID = 8831086203906732583L;
 
+	/**
+	 *  Clamps this tuple to the range [low, high].
+	 *  @param min  the lowest value in this tuple after clamping
+	 *  @param max  the highest value in this tuple after clamping
+	 */
 	public abstract void clamp(float min, float max);
+
+	/**
+	 *  Clamps the tuple parameter to the range [low, high] and
+	 *  places the values into this tuple.
+	 *  @param min   the lowest value in the tuple after clamping
+	 *  @param max  the highest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clamp(float min, float max, T t);
+
+	/**
+	 *  Clamps the maximum value of this tuple to the max parameter.
+	 *  @param max   the highest value in the tuple after clamping
+	 */
 	public abstract void clampMax(float max);
+
+	/**
+	 *  Clamps the maximum value of the tuple parameter to the max
+	 *  parameter and places the values into this tuple.
+	 *  @param max   the highest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clampMax(float max, T t);
+
+	/**
+	 *  Clamps the minimum value of this tuple to the min parameter.
+	 *  @param min   the lowest value in this tuple after clamping
+	 */
 	public abstract void clampMin(float min);
+
+	/**
+	 *  Clamps the minimum value of the tuple parameter to the min
+	 *  parameter and places the values into this tuple.
+	 *  @param min   the lowest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clampMin(float min, T t);
+
+	/**
+	 * Gets the value of this tuple and copies the values into t.
+	 * @param t  the array into which the values are copied
+	 */
 	public abstract void get(float[] t);
+
+	/**
+	 * Sets the value of this vector to the scalar multiplication
+	 * of tuple t1.
+	 * @param s the scalar value
+	 * @param t1 the source tuple
+	 */
 	public abstract void scale(float s);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of the scale factor with this.
+	 * @param s the scalar value
+	 */
 	public abstract void scale(float s, T t);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of itself and then adds tuple t1 (this = s*this + t1).
+	 * @param s the scalar value
+	 * @param t1 the tuple to be added
+	 */
 	public abstract void scaleAdd(float s, T t);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of tuple t1 and then adds tuple t2 (this = s*t1 + t2).
+	 * @param s the scalar value
+	 * @param t1 the tuple to be scaled and added
+	 * @param t2 the tuple to be added without a scale
+	 */
 	public abstract void scaleAdd(float s, T t1, T t2);
+
+	/**
+	 * Sets the value of this tuple to the coordinates specified in
+	 * the array.
+	 * @param t the array containing the coordintes in order
+	 */
 	public abstract void set(float[] t);
 
 }

--- a/src/javax/vecmath/Tuplef.java
+++ b/src/javax/vecmath/Tuplef.java
@@ -2,6 +2,8 @@ package javax.vecmath;
 
 public abstract class Tuplef<T extends Tuplef<T>> extends Tuple<T> {
 
+	private static final long serialVersionUID = 8831086203906732583L;
+
 	public abstract void clamp(float min, float max);
 	public abstract void clamp(float min, float max, T t);
 	public abstract void clampMax(float max);

--- a/src/javax/vecmath/Tuplei.java
+++ b/src/javax/vecmath/Tuplei.java
@@ -1,0 +1,18 @@
+package javax.vecmath;
+
+public abstract class Tuplei<T extends Tuplei<T>> extends Tuple<T> {
+
+	public abstract void clamp(int min, int max);
+	public abstract void clamp(int min, int max, T t);
+	public abstract void clampMax(int max);
+	public abstract void clampMax(int max, T t);
+	public abstract void clampMin(int min);
+	public abstract void clampMin(int min, T t);
+	public abstract void get(int[] t);
+	public abstract void scale(int s);
+	public abstract void scale(int s, T t);
+	public abstract void scaleAdd(int s, T t);
+	public abstract void scaleAdd(int s, T t1, T t2);
+	public abstract void set(int[] t);
+
+}

--- a/src/javax/vecmath/Tuplei.java
+++ b/src/javax/vecmath/Tuplei.java
@@ -1,20 +1,105 @@
 package javax.vecmath;
 
+/**
+ * This class describes a Tuple that holds ints. The number of ints is
+ * determined by subclasses. 
+ *
+ * @param <T> The type of this tuple. Subclasses should provide themselves to
+ *   fill this parameter.
+ *
+ * @since 1.6
+ */
 public abstract class Tuplei<T extends Tuplei<T>> extends Tuple<T> {
 
 	private static final long serialVersionUID = -7508116170295643350L;
 
+	/**
+	 *  Clamps this tuple to the range [low, high].
+	 *  @param min  the lowest value in this tuple after clamping
+	 *  @param max  the highest value in this tuple after clamping
+	 */
 	public abstract void clamp(int min, int max);
+
+	/**
+	 *  Clamps the tuple parameter to the range [low, high] and
+	 *  places the values into this tuple.
+	 *  @param min   the lowest value in the tuple after clamping
+	 *  @param max  the highest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clamp(int min, int max, T t);
+
+	/**
+	 *  Clamps the maximum value of this tuple to the max parameter.
+	 *  @param max   the highest value in the tuple after clamping
+	 */
 	public abstract void clampMax(int max);
+
+	/**
+	 *  Clamps the maximum value of the tuple parameter to the max
+	 *  parameter and places the values into this tuple.
+	 *  @param max   the highest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clampMax(int max, T t);
+
+	/**
+	 *  Clamps the minimum value of this tuple to the min parameter.
+	 *  @param min   the lowest value in this tuple after clamping
+	 */
 	public abstract void clampMin(int min);
+
+	/**
+	 *  Clamps the minimum value of the tuple parameter to the min
+	 *  parameter and places the values into this tuple.
+	 *  @param min   the lowest value in the tuple after clamping
+	 *  @param t   the source tuple, which will not be modified
+	 */
 	public abstract void clampMin(int min, T t);
+
+	/**
+	 * Gets the value of this tuple and copies the values into t.
+	 * @param t  the array into which the values are copied
+	 */
 	public abstract void get(int[] t);
+
+	/**
+	 * Sets the value of this vector to the scalar multiplication
+	 * of tuple t1.
+	 * @param s the scalar value
+	 * @param t1 the source tuple
+	 */
 	public abstract void scale(int s);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of the scale factor with this.
+	 * @param s the scalar value
+	 */
 	public abstract void scale(int s, T t);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of itself and then adds tuple t1 (this = s*this + t1).
+	 * @param s the scalar value
+	 * @param t1 the tuple to be added
+	 */
 	public abstract void scaleAdd(int s, T t);
+
+	/**
+	 * Sets the value of this tuple to the scalar multiplication
+	 * of tuple t1 and then adds tuple t2 (this = s*t1 + t2).
+	 * @param s the scalar value
+	 * @param t1 the tuple to be scaled and added
+	 * @param t2 the tuple to be added without a scale
+	 */
 	public abstract void scaleAdd(int s, T t1, T t2);
+
+	/**
+	 * Sets the value of this tuple to the coordinates specified in
+	 * the array.
+	 * @param t the array containing the coordinates in order
+	 */
 	public abstract void set(int[] t);
 
 }

--- a/src/javax/vecmath/Tuplei.java
+++ b/src/javax/vecmath/Tuplei.java
@@ -2,6 +2,8 @@ package javax.vecmath;
 
 public abstract class Tuplei<T extends Tuplei<T>> extends Tuple<T> {
 
+	private static final long serialVersionUID = -7508116170295643350L;
+
 	public abstract void clamp(int min, int max);
 	public abstract void clamp(int min, int max, T t);
 	public abstract void clampMax(int max);


### PR DESCRIPTION
I've added a hierarchy for Tuples in my fork. The hierarchy looks like this:

* Tuple
    * Tupled
        * Tuple2d, Tuple3d, Tuple4d
    * Tuplef
        * Tuple2f, Tuple3f, Tuple4f
    * Tuplei
        * Tuple2i, Tuple3i, Tuple4i

Tupleb is missing from this because the Tuple*b classes don't currently have many of the methods that other Tuples do. The upper-level classes in this hierarchy declare useful abstract methods, so that it is possible to write code like this:

```java
	// Average method for Tuples of type double
	@SafeVarargs
	public static <T extends Tupled<T>> T average(Tuple<T>... tuples) {
		T avg = sum(tuples);
		avg.scale(1.0 / ((double) tuples.length));
		return avg;
	}

	// Sum method for all Tuples
	@SuppressWarnings("unchecked")
	@SafeVarargs
	public static <T extends Tuple<T>> T sum(Tuple<T>... tuples) {
		T sum = (T) tuples[0].clone();
		for (int i = 1; i < tuples.length; i++) {
			sum.add((T) tuples[i]);
		}
		return sum;
	}
```

This resolves #3.